### PR TITLE
fix: move to self hosted runners

### DIFF
--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -37,8 +37,9 @@ jobs:
         with:
           juju-channel: 3.6/stable
           provider: microk8s
-          channel: 1.31-strict/stable
+          channel: 1.32-strict/stable
           bootstrap-options: '--agent-version=3.6.4'
+          microk8s-addons: "dns hostpath-storage metallb:10.64.140.43-10.64.140.49"
 
       - name: Get charm info
         id: get-charm-info

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -26,7 +26,7 @@ jobs:
 
   integration-test:
     name: Integration Tests (microk8s)
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, amd64, xlarge, jammy]
     needs: build
     steps:
       - name: Checkout

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -3,10 +3,6 @@ name: Integration Tests
 on:
   workflow_call:
     inputs:
-      charm-name:
-        description: Name of the charmed application the tests are running for
-        required: false
-        type: string
       container-name:
         description: Name of the application container to get logs from
         required: false
@@ -44,6 +40,11 @@ jobs:
           channel: 1.28-strict/stable
           bootstrap-options: '--agent-version=3.4.0'
 
+      - name: Get charm info
+        id: get-charm-info
+        run: |
+          echo charm-name=$(cat charmcraft.yaml | yq '.name') >> $GITHUB_OUTPUT
+
       - name: Set CHARM_PATH envvar
         run: echo "CHARM_PATH=${{ github.workspace }}/${{ needs.build.outputs.charm-paths }}" >> $GITHUB_ENV
 
@@ -68,18 +69,18 @@ jobs:
         uses: canonical/charming-actions/dump-logs@main
 
       - name: Get juju logs for the charm
-        if: ${{ failure() && (inputs.charm-name != '') }}
-        run: juju debug-log --replay --include ${{ inputs.charm-name }}/0
+        if: ${{ failure() }}
+        run: juju debug-log --replay --include ${{ steps.get-charm-info.outputs.charm-name }}/0
 
       - name: Get container logs
-        if: ${{ failure() && (inputs.charm-name != '') && (inputs.container-name != '') }}
-        run: kubectl logs ${{ inputs.charm-name }}-0 -c ${{ inputs.container-name }} -n testing
+        if: ${{ failure() && (inputs.container-name != '') }}
+        run: kubectl logs ${{ steps.get-charm-info.outputs.charm-name }}-0 -c ${{ inputs.container-name }} -n testing
 
       # Hack to overcome lack of tools (cat, tar) in the workload container
       - name: Get config file
-        if: ${{ failure() && (inputs.charm-config-path != '') && (inputs.charm-name != '') && (inputs.container-name != '') }}
+        if: ${{ failure() && (inputs.charm-config-path != '') && (inputs.container-name != '') }}
         run: |
-           juju ssh ${{ inputs.charm-name }}/0 "PYTHONPATH=agents/unit-${{ inputs.charm-name }}-0/charm/venv/ python3 -c '
+           juju ssh ${{ steps.get-charm-info.outputs.charm-name }}/0 "PYTHONPATH=agents/unit-${{ steps.get-charm-info.outputs.charm-name }}-0/charm/venv/ python3 -c '
            from ops import pebble
            p = pebble.Client(\"/charm/containers/${{ inputs.container-name }}/pebble.socket\")
            f = p.pull(\"${{ inputs.charm-config-path }}\")

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -35,10 +35,10 @@ jobs:
       - name: Setup operator environment (microk8s)
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.4/stable
+          juju-channel: 3.6/stable
           provider: microk8s
-          channel: 1.28-strict/stable
-          bootstrap-options: '--agent-version=3.4.0'
+          channel: 1.31-strict/stable
+          bootstrap-options: '--agent-version=3.6.4'
 
       - name: Get charm info
         id: get-charm-info

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      node-size:
+        description: Size of the self-hosted node (one of medium, large or xlarge) to run the integration tests
+        type: string
+        required: false
+        default: large
 
 jobs:
   build:
@@ -24,10 +29,20 @@ jobs:
     with:
       use-charmcraftcache: ${{ inputs.use-charmcraftcache }}
 
+  node-size-validation:
+    runs-on: ubuntu-latest
+    name: Input Node Size validation
+    steps:
+      - name: Validate node size variable
+        if: ${{ !contains(fromJSON('["medium", "large", "xlarge"]'), inputs.node-size) }}
+        run: exit 1
+
   integration-test:
     name: Integration Tests (microk8s)
-    runs-on: [self-hosted, amd64, xlarge, jammy]
-    needs: build
+    runs-on: [self-hosted, amd64, "${{ inputs.node-size }}", jammy]
+    needs:
+      - build
+      - node-size-validation
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,7 +53,6 @@ jobs:
           juju-channel: 3.6/stable
           provider: microk8s
           channel: 1.32-strict/stable
-          bootstrap-options: '--agent-version=3.6.4'
           microk8s-addons: "dns hostpath-storage metallb:10.64.140.43-10.64.140.49"
 
       - name: Get charm info

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -3,10 +3,6 @@ name: Pull Request Workflow
 on:
   workflow_call:
     inputs:
-      charm-name:
-        description: Name of the charmed application the tests are running for
-        required: false
-        type: string
       container-name:
         description: Name of the application container to get logs from
         required: false
@@ -39,7 +35,6 @@ jobs:
     name: Integration Tests
     uses: ./.github/workflows/_charm-tests-integration.yaml
     with:
-      charm-name: ${{ inputs.charm-name }}
       container-name: ${{ inputs.container-name }}
       charm-config-path: ${{ inputs.charm-config-path }}
       use-charmcraftcache: ${{ inputs.use-charmcraftcache }}

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      node-size:
+        description: Size of the self-hosted node (one of medium, large or xlarge) to run the integration tests
+        type: string
+        required: false
+        default: large
     secrets:
       CHARMCRAFT_CREDENTIALS:
         required: false
@@ -38,6 +43,7 @@ jobs:
       container-name: ${{ inputs.container-name }}
       charm-config-path: ${{ inputs.charm-config-path }}
       use-charmcraftcache: ${{ inputs.use-charmcraftcache }}
+      node-size: ${{ inputs.node-size }}
     needs:
       - linting
       - unit-test


### PR DESCRIPTION
- **fix: drop charm-name input and infer it from charmcraft.yaml**
- **fix: update k89s and juju versions**
- **fix: specify addons for microk8s**
- **fix: use self hosted runners to overcome disk issues when running integration tests**
- **fix: specify node size as input**
