### PR TITLE
fix: make the charm lib update workflow use the conventional commit message

### DIFF
--- a/.github/workflows/charm-libs-update.yaml
+++ b/.github/workflows/charm-libs-update.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: canonical/create-pull-request@main
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
-          commit-message: Update charm dependent libs
+          commit-message: 'fix: update charm dependent libs'
           branch-name: 'automated-update-charm-libs'
           title: (Automated) Update Charm Dependent Libs
           body: Update charm dependent libraries


### PR DESCRIPTION
This will resolve the issue in this [CI run](https://github.com/canonical/hydra-operator/actions/runs/14308255268/job/40096887798):

```
❯ commit could not be parsed: f6a4b7afe6b5e71f14cf0ab32d1b2c82c6adef5c Update charm libs
❯ error message: Error: unexpected token ' ' at 1:7, valid tokens [(, !, :]
```