### PR TITLE
Make application resource path configurable

### DIFF
--- a/.github/workflows/charm-deploy.yaml
+++ b/.github/workflows/charm-deploy.yaml
@@ -16,6 +16,15 @@ on:
         channel:
             type: string
             required: true
+        tf-application-resource:
+            type: string
+            # Set this default for backwards compatibility.
+            # TODO(nsklikas): When all repos have migrated to use the charm tf
+            # module to deploy then we should change the default to
+            # "module.application.juju_application.application".
+            # See https://github.com/canonical/identity-team/issues/63
+            default: "juju_application.application"
+            required: false
         tf-folder:
             type: string
             default: "./deployment"
@@ -47,13 +56,13 @@ jobs:
         working-directory: ${{ inputs.tf-folder }}
         run: |
           terraform init
-          terraform import juju_application.application ${{ inputs.model}}:${{ inputs.application }} || true
+          terraform import ${{ inputs.tf-application-resource }} ${{ inputs.model}}:${{ inputs.application }} || true
         env:
           TF_VAR_model: ${{ inputs.model }}
           TF_VAR_revision: ${{ inputs.revision }}
           TF_VAR_channel: ${{ inputs.channel }}
           TF_VAR_application_name: "${{ inputs.application }}"
-          
+
       - name: Deploy
         working-directory: ${{ inputs.tf-folder }}
         run: |


### PR DESCRIPTION
Allows the caller to define the path of the application resource. This way we can reuse the module that's in the `terraform` folder to deploy to dev/staging, e.g. see https://github.com/canonical/user-verification-service-operator/pull/64/files#diff-7eb3ee0f98ada933aa3e4a260350c6c2b27b030633e9aa16afecba0ca056ef6fR66