### PR TITLE
refactor: update cron schedule to run at 8 AM on weekdays

### DIFF
--- a/.github/workflows/mattermost-daily.yml
+++ b/.github/workflows/mattermost-daily.yml
@@ -1,7 +1,7 @@
 name: mattermost-daily-message
 on:
   schedule:
-    - cron: '0 7 * * 1-5'
+    - cron: '0 8 * * 1-5'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description
Update cron schedule to run at 8 AM on weekdays after daylight savings time is over.
We'll need to push this back in march when daylight savings is back.
