### PR TITLE
Support ignored restrictions in rockcraft build

### DIFF
--- a/.github/workflows/_rock-build.yaml
+++ b/.github/workflows/_rock-build.yaml
@@ -9,6 +9,11 @@ on:
         default: false
         required: false
         description: "Flag defining if structure tests are present"
+      ignore-restrictions:
+        type: string
+        default: ""
+        required: false
+        description: "Comma separated list of ignored restrictions (e.g. 'unmaintained')"
     outputs:
       rock:
         description: "rock image"
@@ -26,6 +31,8 @@ jobs:
 
       - uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
+        with:
+          ignore: ${{ inputs.ignore-restrictions }}
 
       - name: Install Rockcraft to get Skopeo
         run: sudo snap install --classic --channel latest/stable rockcraft


### PR DESCRIPTION
This pull request adds support for the `ignore` list in the rockcraft pack step. More information can be found in https://github.com/canonical/craft-actions/tree/main/rockcraft-pack.