### PR TITLE
Make permissions explicit for calling workflows to use

### DIFF
--- a/.github/workflows/_rock-gh-publish.yaml
+++ b/.github/workflows/_rock-gh-publish.yaml
@@ -15,6 +15,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      packages: write
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.set.outputs.image }}

--- a/.github/workflows/_rock-scan.yaml
+++ b/.github/workflows/_rock-scan.yaml
@@ -10,10 +10,15 @@ on:
         description: "image to scan"
 jobs:
   scan:
+    permissions:
+      packages: read
+      contents: read
+      security-events: write
+      actions: read
     runs-on: ubuntu-latest
     steps:
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ inputs.image }}
           format: 'sarif'

--- a/.github/workflows/cve-check.yaml
+++ b/.github/workflows/cve-check.yaml
@@ -25,6 +25,9 @@ permissions:
 
 jobs:
   cve-labelling:
+    permissions:
+      contents: write
+      issues: write
     runs-on: ubuntu-24.04
     steps:
       - run: echo issue=${{ inputs.issue }} >> $GITHUB_ENV


### PR DESCRIPTION
## Description
Make permissions explicit for calling workflows to use, so we don't incur in failures in downstream repos of ours.

#### Also
Trivy gets pinned to `v0.36.0`.