### PR TITLE
Try to fix timezone evaluation in daily matrix job + disable mattermost daily message

### DIFF
--- a/.github/workflows/mattermost-daily.yml
+++ b/.github/workflows/mattermost-daily.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   daily-message-mattermost:
     runs-on: ubuntu-latest
+    if: false
     steps:
       - name: Check schedule window
         id: timegate
@@ -56,8 +57,6 @@ jobs:
 
   daily-message-matrix:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.25
     steps:
       - name: Check schedule window
         id: timegate
@@ -92,6 +91,12 @@ jobs:
       - name: Checkout repository
         if: steps.timegate.outputs.run == 'true'
         uses: actions/checkout@v4
+      - name: Setup Go
+        if: steps.timegate.outputs.run == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache-dependency-path: tools/matrix-daily/go.sum
       - name: Run Matrix Sender
         if: steps.timegate.outputs.run == 'true'
         working-directory: ./tools/matrix-daily


### PR DESCRIPTION
## Description

 - Remove the container definition from the 'daily-message-matrix' job to run steps directly on the 'ubuntu-latest' host. Standard runner environments have the 'tzdata' package pre-installed, ensuring 'TZ=Europe/Paris date +%z' evaluates timezone offsets correctly instead of defaulting to UTC (+0000). This avoids having to manually configure or install local timezone packages.
- Add the 'actions/setup-go@v5' step to configure the Go environment on the host, which also helps to minimise startup latency.
- Disable the 'daily-message-mattermost' job by adding 'if: false' at the job level.