### PR TITLE
fix: add package permissions

### DIFF
--- a/.github/workflows/_rock-gh-publish-third-party.yaml
+++ b/.github/workflows/_rock-gh-publish-third-party.yaml
@@ -16,6 +16,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      packages: write
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.set.outputs.image }}


### PR DESCRIPTION
attempts to fix the publish issue: `"level=fatal msg="writing blob: initiating layer upload to /v2/canonical/kratos/blobs/uploads/ in ghcr.io: denied: installation not allowed to Write organization package"`