### PR TITLE
feat: add `multi-arch` parameter

### DIFF
--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -70,7 +70,7 @@ jobs:
 
   integration-test:
     name: Integration Tests (microk8s) (${{ inputs.architecture }})
-    runs-on: ${{ fromJSON(format('["self-hosted", "{0}", "{1}", "noble"]', inputs.architecture, inputs.node-size)) }}
+    runs-on: ${{ fromJSON(format('["self-hosted", "{0}", "{1}", "jammy"]', inputs.architecture, inputs.node-size)) }}
     needs:
       - build
       - node-size-validation

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -46,6 +46,11 @@ on:
         description: Run integration tests with tmate debugging enabled
         required: false
         default: false
+      multi-arch:
+        description: Run integration tests on all architectures defined in the platforms of charmcraft.yaml
+        required: false
+        default: false
+        type: boolean
     secrets:
       CHARMCRAFT_CREDENTIALS:
         required: false
@@ -58,13 +63,15 @@ jobs:
   check:
     runs-on: ubuntu-24.04
     outputs:
-      architectures: ${{ steps.info.outputs.architectures }}
+      architectures: ${{ inputs.multi-arch && steps.info.outputs.architectures || '["amd64"]' }}
     steps:
       - name: Checkout
+        if: ${{ inputs.multi-arch }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
       - name: Get charm info
+        if: ${{ inputs.multi-arch }}
         id: info
         run: |
           platforms_json=$(cat charmcraft.yaml | yq '.platforms | keys | tojson')


### PR DESCRIPTION
This PR adds a parameter to specify whether charm integration tests should run on a matrix of all supported architectures. If set to false, it will continue to run on amd64 only.

The reason I added it is that there are less arm64 self-hosted runners available, which increases the CI runtime.