### PR TITLE
feat: install dependencies if missing

### DIFF
--- a/.github/workflows/_charm-build.yaml
+++ b/.github/workflows/_charm-build.yaml
@@ -56,11 +56,21 @@ jobs:
       - name: Install charmcraft
         run: |
           sudo snap install charmcraft --classic --channel ${{ inputs.charmcraft-channel }}
+          if ! command -v yq &> /dev/null; then
+            sudo snap install yq
+          fi
+          if ! command -v jq &> /dev/null; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
           echo CHARMCRAFT_BIN=charmcraft >> $GITHUB_ENV
       - name: Install charmcraftcache
         if: ${{ inputs.use-charmcraftcache }}
         run: |
+          if ! command -v pipx &> /dev/null; then
+            sudo apt-get update && sudo apt-get install -y pipx
+          fi
           pipx install charmcraftcache
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo CHARMCRAFT_BIN=ccc >> $GITHUB_ENV
       - name: Build charm
         run: ${{ env.CHARMCRAFT_BIN}} pack -v


### PR DESCRIPTION
The `arm64` self-hosted runners don't have the same packages pre-installed as on `amd64`, causing the charm build step to fail (https://github.com/canonical/kratos-operator/actions/runs/28589293420/job/84771939279#step:6:8). This PR makes sure that these dependencies are installed.