### PR TITLE
feat: support multiple bases

### DIFF
--- a/.github/workflows/_charm-build.yaml
+++ b/.github/workflows/_charm-build.yaml
@@ -17,6 +17,11 @@ on:
         required: false
         default: amd64
         type: string
+      base:
+        description: Ubuntu base to build for (e.g. 22.04, 24.04, 26.04)
+        required: false
+        default: "22.04"
+        type: string
       runner:
         description: Override the runner to run on. If empty, standard native runners are used.
         required: false
@@ -38,7 +43,15 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (inputs.architecture == 'arm64' && 'self-hosted-linux-arm64-noble-medium' || 'ubuntu-latest') }}
+    runs-on: >-
+      ${{ inputs.runner != '' && inputs.runner || (
+        inputs.architecture == 'arm64' && (
+          inputs.base == '26.04' && 'self-hosted-linux-arm64-resolute-large' ||
+          inputs.base == '24.04' && 'self-hosted-linux-arm64-noble-medium' ||
+          inputs.base == '22.04' && 'self-hosted-linux-arm64-jammy-medium' ||
+          format('self-hosted-linux-arm64-{0}-medium', inputs.base)
+        ) || format('ubuntu-{0}', inputs.base)
+      ) }}
     outputs:
       name: ${{ steps.get-charm-info.outputs.charm-name }}
       platforms: ${{ steps.get-charm-info.outputs.charm-platforms }}
@@ -72,8 +85,25 @@ jobs:
           pipx install charmcraftcache
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo CHARMCRAFT_BIN=ccc >> $GITHUB_ENV
+      - name: Resolve platform
+        id: resolve-platform
+        run: |
+          canonical_platform="ubuntu@${{ inputs.base }}:${{ inputs.architecture }}"
+          charm_base=$(cat charmcraft.yaml | yq '.base // ""')
+          platforms_json=$(cat charmcraft.yaml | yq '.platforms | keys | tojson')
+
+          if echo "$platforms_json" | jq -e --arg platform "$canonical_platform" 'index($platform) != null' > /dev/null; then
+            platform="$canonical_platform"
+          elif [ "$charm_base" = "ubuntu@${{ inputs.base }}" ] && echo "$platforms_json" | jq -e --arg architecture "${{ inputs.architecture }}" 'index($architecture) != null' > /dev/null; then
+            platform="${{ inputs.architecture }}"
+          else
+            echo "No platform found for Ubuntu ${{ inputs.base }} on ${{ inputs.architecture }}" >&2
+            exit 1
+          fi
+
+          echo "platform=$platform" >> "$GITHUB_OUTPUT"
       - name: Build charm
-        run: ${{ env.CHARMCRAFT_BIN}} pack -v
+        run: ${{ env.CHARMCRAFT_BIN }} pack --platform "${{ steps.resolve-platform.outputs.platform }}" -v
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Get charm info
@@ -84,9 +114,10 @@ jobs:
       - name: Get charm paths
         id: get-charm-paths
         run: |
-          echo charm-paths=$(echo '${{ steps.get-charm-info.outputs.charm-platforms }}' | jq -r --arg charm ${{ steps.get-charm-info.outputs.charm-name }} --arg arch ${{ inputs.architecture }} 'map(select(contains($arch))) | .[] |= split(":") | .[] |= join("-", .) | map($charm + "_" + . + ".charm") | join(",")') >> $GITHUB_OUTPUT
+          platform="${{ steps.resolve-platform.outputs.platform }}"
+          echo "charm-paths=${{ steps.get-charm-info.outputs.charm-name }}_${platform/:/-}.charm" >> "$GITHUB_OUTPUT"
       - id: artifact-name
-        run: echo artifact='${{ github.sha }}-${{ github.job }}-${{ inputs.architecture }}' >> $GITHUB_OUTPUT
+        run: echo artifact='${{ github.sha }}-${{ github.job }}-${{ inputs.base }}-${{ inputs.architecture }}' >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ steps.artifact-name.outputs.artifact }}

--- a/.github/workflows/_charm-linting.yaml
+++ b/.github/workflows/_charm-linting.yaml
@@ -2,19 +2,29 @@ name: Linting
 
 on:
   workflow_call:
-
+    inputs:
+      base:
+        description: Ubuntu base to run linters on (e.g. 22.04, 24.04, 26.04)
+        type: string
+        required: false
+        default: "22.04"
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-${{ inputs.base }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 1
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.base == '26.04' && '3.14' || inputs.base == '24.04' && '3.12' || '3.10' }}
+
       - name: Install dependencies
         run: python3 -m pip install tox
 
       - name: Run linters
-        run: tox -e lint
+        run: tox -e lint --override "testenv:lint.base_python=python3"

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -46,6 +46,16 @@ on:
         required: false
         default: amd64
         type: string
+      base:
+        description: Ubuntu base to test on (e.g. 22.04, 24.04, 26.04)
+        required: false
+        default: "22.04"
+        type: string
+      k8s-channel:
+        description: "The channel of Charmed Kubernetes or MicroK8s to install"
+        type: string
+        required: false
+        default: "1.32-strict/stable"
     secrets:
       GH_USERNAME:
         required: false
@@ -54,11 +64,12 @@ on:
 
 jobs:
   build:
-    name: Build charm (${{ inputs.architecture }})
+    name: Build charm (${{ inputs.base }} | ${{ inputs.architecture }})
     uses: ./.github/workflows/_charm-build.yaml
     with:
       use-charmcraftcache: ${{ inputs.use-charmcraftcache }}
       architecture: ${{ inputs.architecture }}
+      base: ${{ inputs.base }}
 
   node-size-validation:
     runs-on: ubuntu-latest
@@ -69,8 +80,8 @@ jobs:
         run: exit 1
 
   integration-test:
-    name: Integration Tests (microk8s) (${{ inputs.architecture }})
-    runs-on: ${{ fromJSON(format('["self-hosted", "{0}", "{1}", "jammy"]', inputs.architecture, inputs.node-size)) }}
+    name: Integration Tests (microk8s) (${{ inputs.base }} | ${{ inputs.architecture }})
+    runs-on: ${{ fromJSON(format('["self-hosted", "{0}", "{1}", "{2}"]', inputs.architecture, inputs.node-size, inputs.base == '26.04' && 'resolute' || inputs.base == '24.04' && 'noble' || inputs.base == '22.04' && 'jammy' || inputs.base)) }}
     needs:
       - build
       - node-size-validation
@@ -91,8 +102,16 @@ jobs:
         with:
           juju-channel: 3.6/stable
           provider: microk8s
-          channel: 1.32-strict/stable
+          channel: ${{ inputs.k8s-channel }}
           microk8s-addons: "dns hostpath-storage metallb:10.64.140.43-10.64.140.49"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.base == '26.04' && '3.14' || inputs.base == '24.04' && '3.12' || '3.10' }}
+
+      - name: Install test dependencies
+        run: python3 -m pip install tox
 
       - name: Get charm info
         id: get-charm-info
@@ -105,13 +124,17 @@ jobs:
       - name: Download charm artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: ${{ github.sha }}-build-${{ inputs.architecture }}
+          name: ${{ github.sha }}-build-${{ inputs.base }}-${{ inputs.architecture }}
 
       - name: Run integration tests
         env:
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           GH_PAT: ${{ secrets.GH_PAT }}
-        run: tox -e ${{ inputs.tox-integration-test-targets }} -- ${{ inputs.pytest-model-option }} ${{ inputs.juju-model-name }}
+        run: |
+          tox -e "${{ inputs.tox-integration-test-targets }}" \
+            --override "testenv:build-prerequisites.base_python=python3" \
+            --override "testenv:integration.base_python=python3" \
+            -- ${{ inputs.pytest-model-option }} ${{ inputs.juju-model-name }}
 
       - name: Resolve actual juju model name
         id: resolve-model

--- a/.github/workflows/_charm-tests-unit.yaml
+++ b/.github/workflows/_charm-tests-unit.yaml
@@ -8,17 +8,30 @@ on:
         type: string
         required: false
         default: unit
+      base:
+        description: Ubuntu base to run unit tests on (e.g. 22.04, 24.04, 26.04)
+        type: string
+        required: false
+        default: "22.04"
 
 jobs:
   unit-tests:
     name: Unit Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-${{ inputs.base }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.base == '26.04' && '3.14' || inputs.base == '24.04' && '3.12' || '3.10' }}
+
       - name: Install dependencies
-        run: python -m pip install tox
+        run: python3 -m pip install tox
 
       - name: Run unit tests
-        run: tox -e ${{ inputs.tox-unit-test-targets }}
+        run: |
+          tox -e "${{ inputs.tox-unit-test-targets }}" \
+            --override "testenv:build-prerequisites.base_python=python3" \
+            --override "testenv:unit.base_python=python3"

--- a/.github/workflows/charm-publish.yaml
+++ b/.github/workflows/charm-publish.yaml
@@ -35,7 +35,7 @@ jobs:
       channel: ${{ steps.export.outputs.channel }}
       charm-name: ${{ steps.info.outputs.charm-name }}
       architectures: ${{ steps.info.outputs.architectures }}
-      architecture-paths-map: ${{ steps.info.outputs.architecture-paths-map }}
+      platforms: ${{ steps.info.outputs.platforms }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -45,14 +45,34 @@ jobs:
         id: info
         run: |
           charm_name=$(cat charmcraft.yaml | yq '.name')
+          charm_base=$(cat charmcraft.yaml | yq '.base // ""')
           platforms_json=$(cat charmcraft.yaml | yq '.platforms | keys | tojson')
-          
-          architectures=$(echo "$platforms_json" | jq -c 'map(split(":") | last) | unique')
-          architecture_paths_map=$(echo "$platforms_json" | jq -c --arg charm "$charm_name" 'reduce .[] as $item ({}; ($item | split(":") | last) as $arch | ($item | split(":") | join("-")) as $plat | ($charm + "_" + $plat + ".charm") as $path | .[$arch] += (if .[$arch] then "," else "" end + $path))')
-          
+
+          platforms=$(echo "$platforms_json" | jq -c --arg charm "$charm_name" --arg charm_base "$charm_base" '
+            map(. as $platform |
+              if ($platform | contains(":")) then
+                ($platform | split(":")) as $parts |
+                {
+                  base: ($parts[0] | sub("^ubuntu@"; "")),
+                  architecture: $parts[-1],
+                  charm_path: ($charm + "_" + ($platform | gsub(":"; "-")) + ".charm")
+                }
+              elif $charm_base != "" then
+                {
+                  base: ($charm_base | sub("^ubuntu@"; "")),
+                  architecture: $platform,
+                  charm_path: ($charm + "_" + $platform + ".charm")
+                }
+              else
+                error("A top-level base is required for shorthand platform names")
+              end
+            )
+          ')
+          architectures=$(echo "$platforms" | jq -c 'map(.architecture) | unique')
+
           echo "charm-name=$charm_name" >> $GITHUB_OUTPUT
           echo "architectures=$architectures" >> $GITHUB_OUTPUT
-          echo "architecture-paths-map=$architecture_paths_map" >> $GITHUB_OUTPUT
+          echo "platforms=$platforms" >> $GITHUB_OUTPUT
       - name: Get current branch
         id: check_step
         run: "sudo snap install jq --channel latest/edge \n\ntrack=$(echo ${{ github.ref }} | jq -R | jq 'split(\"-\")[0]' | jq 'sub(\"refs/tags/\"; \"\")' | jq 'split(\"/\")[1]')\necho \"track=$track\" >> $GITHUB_OUTPUT\necho \"Track is $track.\"  \n"
@@ -66,25 +86,28 @@ jobs:
         id: export
         run: echo channel=${{ env.channel }} >> $GITHUB_OUTPUT
   build:
-    name: Build charm (${{ matrix.architecture }})
+    name: Build charm (${{ matrix.platform.base }} | ${{ matrix.platform.architecture }})
     needs: check
     strategy:
+      fail-fast: false
       matrix:
-        architecture: ${{ fromJson(needs.check.outputs.architectures) }}
+        platform: ${{ fromJson(needs.check.outputs.platforms) }}
     uses: ./.github/workflows/_charm-build.yaml
     with:
       use-charmcraftcache: ${{ inputs.use-charmcraftcache }}
-      architecture: ${{ matrix.architecture }}
+      architecture: ${{ matrix.platform.architecture }}
+      base: ${{ matrix.platform.base }}
   scan:
     needs: [build, check]
     strategy:
+      fail-fast: false
       matrix:
-        architecture: ${{ fromJson(needs.check.outputs.architectures) }}
+        platform: ${{ fromJson(needs.check.outputs.platforms) }}
     uses: ./.github/workflows/_secscan.yaml
     with:
       artifacts-format: charm
-      artifacts-key: ${{ github.sha }}-build-${{ matrix.architecture }}
-      artifact-paths: ${{ fromJson(needs.check.outputs.architecture-paths-map)[matrix.architecture] }}
+      artifacts-key: ${{ github.sha }}-build-${{ matrix.platform.base }}-${{ matrix.platform.architecture }}
+      artifact-paths: ${{ matrix.platform.charm_path }}
   publish-charm:
     name: Publish Charm
     runs-on: ubuntu-24.04

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -51,6 +51,16 @@ on:
         required: false
         default: false
         type: boolean
+      base:
+        description: Ubuntu base to run/build on (e.g. 22.04, 24.04, 26.04)
+        required: false
+        default: "22.04"
+        type: string
+      k8s-channel:
+        description: "The channel of Charmed Kubernetes or MicroK8s to install"
+        type: string
+        required: false
+        default: "1.32-strict/stable"
     secrets:
       CHARMCRAFT_CREDENTIALS:
         required: false
@@ -61,7 +71,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-${{ inputs.base }}
     outputs:
       architectures: ${{ inputs.multi-arch && steps.info.outputs.architectures || '["amd64"]' }}
     steps:
@@ -74,24 +84,41 @@ jobs:
         if: ${{ inputs.multi-arch }}
         id: info
         run: |
+          charm_base=$(cat charmcraft.yaml | yq '.base // ""')
           platforms_json=$(cat charmcraft.yaml | yq '.platforms | keys | tojson')
-          architectures=$(echo "$platforms_json" | jq -c 'map(split(":") | last) | unique')
+          architectures=$(echo "$platforms_json" | jq -c --arg base "ubuntu@${{ inputs.base }}" --arg charm_base "$charm_base" '
+            map(
+              select(
+                if contains(":") then
+                  (split(":") | first) == $base
+                else
+                  $charm_base == $base
+                end
+              ) |
+              split(":") |
+              last
+            ) |
+            unique
+          ')
           echo "architectures=$architectures" >> $GITHUB_OUTPUT
 
   linting:
     name: Linting
     uses: ./.github/workflows/_charm-linting.yaml
+    with:
+      base: ${{ inputs.base }}
 
   unit-test:
     name: Unit Tests
     uses: ./.github/workflows/_charm-tests-unit.yaml
     with:
       tox-unit-test-targets: ${{ inputs.tox-unit-test-targets }}
+      base: ${{ inputs.base }}
     needs:
       - linting
 
   integration-test:
-    name: Integration Tests (${{ matrix.architecture }})
+    name: Integration Tests (${{ inputs.base }} | ${{ matrix.architecture }})
     needs:
       - linting
       - unit-test
@@ -113,3 +140,5 @@ jobs:
       juju-model-name: ${{ inputs.juju-model-name }}
       debug-enabled: ${{ inputs.debug-enabled }}
       architecture: ${{ matrix.architecture }}
+      base: ${{ inputs.base }}
+      k8s-channel: ${{ inputs.k8s-channel }}

--- a/.github/workflows/charm-release-pull-request.yaml
+++ b/.github/workflows/charm-release-pull-request.yaml
@@ -1,0 +1,142 @@
+# Run pre-release integration tests for all supported architectures and bases. Lint and unit tests are run once, on the base defined in the workflow input.
+name: Release Pull Request Workflow
+
+on:
+  workflow_call:
+    inputs:
+      container-name:
+        description: Name of the application container to get logs from
+        required: false
+        type: string
+      charm-config-path:
+        description: Path to the application config file
+        required: false
+        type: string
+      use-charmcraftcache:
+        description: Enable usage of charmcraftcache
+        required: false
+        default: false
+        type: boolean
+      node-size:
+        description: Size of the self-hosted node (one of medium, large or xlarge) to run the integration tests
+        type: string
+        required: false
+        default: large
+      tox-unit-test-targets:
+        description: Comma separated list of tox targets needed to perform unit-tests
+        type: string
+        required: false
+        default: unit
+      tox-integration-test-targets:
+        description: Comma separated list of tox targets needed to perform integration-tests
+        type: string
+        required: false
+        default: integration
+      pytest-model-option:
+        description: "CLI option to pass the model name to pytest (use '--juju-model' for pytest-jubilant 2.0)"
+        type: string
+        required: false
+        default: "--model"
+      juju-model-name:
+        description: "Juju model name passed to pytest. With jubilant 2.0 this is a prefix; the actual model is auto-discovered for debug steps."
+        type: string
+        required: false
+        default: "testing"
+      debug-enabled:
+        type: boolean
+        description: Run integration tests with tmate debugging enabled
+        required: false
+        default: false
+      base:
+        description: Ubuntu base to run linting and unit tests on
+        required: false
+        default: "22.04"
+        type: string
+      k8s-channel:
+        description: "The channel of Charmed Kubernetes or MicroK8s to install"
+        type: string
+        required: false
+        default: "1.35-strict/stable"
+    secrets:
+      CHARMCRAFT_CREDENTIALS:
+        required: false
+      GH_USERNAME:
+        required: false
+      GH_PAT:
+        required: false
+
+jobs:
+  check:
+    runs-on: ubuntu-${{ inputs.base }}
+    outputs:
+      platforms: ${{ steps.info.outputs.platforms }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+      - name: Get charm info
+        id: info
+        run: |
+          charm_base=$(cat charmcraft.yaml | yq '.base // ""')
+          platforms_json=$(cat charmcraft.yaml | yq '.platforms | keys | tojson')
+          platforms=$(echo "$platforms_json" | jq -c --arg charm_base "$charm_base" '
+            map(. as $platform |
+              if ($platform | contains(":")) then
+                ($platform | split(":")) as $parts |
+                {
+                  base: ($parts[0] | sub("^ubuntu@"; "")),
+                  architecture: $parts[-1]
+                }
+              elif $charm_base != "" then
+                {
+                  base: ($charm_base | sub("^ubuntu@"; "")),
+                  architecture: $platform
+                }
+              else
+                error("A top-level base is required for shorthand platform names")
+              end
+            )
+          ')
+          echo "platforms=$platforms" >> "$GITHUB_OUTPUT"
+
+  linting:
+    name: Linting
+    uses: ./.github/workflows/_charm-linting.yaml
+    with:
+      base: ${{ inputs.base }}
+
+  unit-test:
+    name: Unit Tests
+    needs: linting
+    uses: ./.github/workflows/_charm-tests-unit.yaml
+    with:
+      tox-unit-test-targets: ${{ inputs.tox-unit-test-targets }}
+      base: ${{ inputs.base }}
+
+  integration-test:
+    name: Integration Tests (${{ matrix.platform.base }} | ${{ matrix.platform.architecture }})
+    needs:
+      - check
+      - linting
+      - unit-test
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.check.outputs.platforms) }}
+    uses: ./.github/workflows/_charm-tests-integration.yaml
+    secrets:
+      GH_USERNAME: ${{ secrets.GH_USERNAME }}
+      GH_PAT: ${{ secrets.GH_PAT }}
+    with:
+      container-name: ${{ inputs.container-name }}
+      charm-config-path: ${{ inputs.charm-config-path }}
+      use-charmcraftcache: ${{ inputs.use-charmcraftcache }}
+      node-size: ${{ inputs.node-size }}
+      tox-integration-test-targets: ${{ inputs.tox-integration-test-targets }}
+      pytest-model-option: ${{ inputs.pytest-model-option }}
+      juju-model-name: ${{ inputs.juju-model-name }}
+      debug-enabled: ${{ inputs.debug-enabled }}
+      architecture: ${{ matrix.platform.architecture }}
+      base: ${{ matrix.platform.base }}
+      k8s-channel: ${{ inputs.k8s-channel }}


### PR DESCRIPTION
## Summary

  - Added base-aware charm build, lint, unit, and integration workflows for different Ubuntu bases (we use 22.04, 24.04, and/or 26.04 in our charms).
  - Workflows now select matching runners and Python versions for each Ubuntu base.
  - Added configurable Kubernetes channel support for integration tests (with `1.35-strict/stable` required for 26.04)
  - Updated publish action to build and scan every base/architecture declared in `charmcraft.yaml`.
  - Preserved compatibility with canonical multi-base and legacy shorthand platform definitions.
  - Added a new optional workflow `charm-release-pull-request.yaml`: lint/unit checks run once on the selected base, while integration tests run across all supported platforms. This workflow can be called pre-release (on `release-please--branches--main` ref branch). We continue to test only on one selected base/architecture pair on standard pull requests.
  - Workflows continue to run on `22.04` by default, so that we don't break the existing workflows (most of them are set to jammy). Once we confirm there are no further compatibility issues, we can set 26.04 as a global default.
- Python override: Existing charms pin `base_python=python3.10` in tox configuration. On newer bases, tox would continue searching for Python 3.10 even though 24.04+ uses a different python version by default.
  The CLI overrides switch standard CI environments to python3, which resolves to the base-appropriate Python version while leaving downstream charm configuration unchanged.

I tested the multi-base support CI checks in https://github.com/canonical/glauth-k8s-operator/pull/299, updating the base to 26.04 and microk8s version to 1.35.

closes https://github.com/canonical/identity-team/issues/138